### PR TITLE
fix: deprecated ::set-output

### DIFF
--- a/.github/workflows/cancel_duplicates.yml
+++ b/.github/workflows/cancel_duplicates.yml
@@ -24,7 +24,7 @@ jobs:
           }
           count=$(( `get_count queued` + `get_count in_progress` ))
           echo "Found $count unfinished jobs."
-          echo "::set-output name=count::$count"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
 
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         if: steps.check_queued.outputs.count >= 20

--- a/.github/workflows/docker-ephemeral-env.yml
+++ b/.github/workflows/docker-ephemeral-env.yml
@@ -47,11 +47,11 @@ jobs:
 
     - name: Get SHA
       id: get-sha
-      run: echo "::set-output name=sha::$(cat ./SHA)"
+      run: echo "sha=$(cat ./SHA)" >> "$GITHUB_OUTPUT"
 
     - name: Get PR
       id: get-pr
-      run: echo "::set-output name=num::$(cat ./PR-NUM)"
+      run: echo "num=$(cat ./PR-NUM)" >> "$GITHUB_OUTPUT"
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Describe ECS service
         id: describe-services
         run: |
-          echo "::set-output name=active::$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')"
+          echo "active=$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')" >> "$GITHUB_OUTPUT"
 
       - name: Delete ECS service
         if: steps.describe-services.outputs.active == 'true'

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Describe ECS service
       id: describe-services
       run: |
-        echo "::set-output name=active::$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.issue.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')"
+        echo "active=$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.issue.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')" >> "$GITHUB_OUTPUT"
 
     - name: Create ECS service
       if: steps.describe-services.outputs.active != 'true'
@@ -155,17 +155,17 @@ jobs:
     - name: List tasks
       id: list-tasks
       run: |
-        echo "::set-output name=task::$(aws ecs list-tasks --cluster superset-ci --service-name pr-${{ github.event.issue.number }}-service | jq '.taskArns | first')"
+        echo "task=$(aws ecs list-tasks --cluster superset-ci --service-name pr-${{ github.event.issue.number }}-service | jq '.taskArns | first')" >> "$GITHUB_OUTPUT"
 
     - name: Get network interface
       id: get-eni
       run: |
-        echo "::set-output name=eni::$(aws ecs describe-tasks --cluster superset-ci --tasks ${{ steps.list-tasks.outputs.task }} | jq '.tasks | .[0] | .attachments | .[0] | .details | map(select(.name=="networkInterfaceId")) | .[0] | .value')"
+        echo "eni=$(aws ecs describe-tasks --cluster superset-ci --tasks ${{ steps.list-tasks.outputs.task }} | jq '.tasks | .[0] | .attachments | .[0] | .details | map(select(.name=="networkInterfaceId")) | .[0] | .value')" >> "$GITHUB_OUTPUT"
 
     - name: Get public IP
       id: get-ip
       run: |
-        echo "::set-output name=ip::$(aws ec2 describe-network-interfaces --network-interface-ids ${{ steps.get-eni.outputs.eni }} | jq -r '.NetworkInterfaces | first | .Association.PublicIp')"
+        echo "ip=$(aws ec2 describe-network-interfaces --network-interface-ids ${{ steps.get-eni.outputs.eni }} | jq -r '.NetworkInterfaces | first | .Association.PublicIp')" >> "$GITHUB_OUTPUT"
 
     - name: Comment (success)
       if: ${{ success() }}

--- a/.github/workflows/prefer-typescript.yml
+++ b/.github/workflows/prefer-typescript.yml
@@ -35,7 +35,7 @@ jobs:
               ) | join("\n")
             ' ${HOME}/files_added.json
           }
-          echo ::set-output name=js_files_added::$(js_files_added)
+          echo "js_files_added=$(js_files_added)" >> "$GITHUB_OUTPUT"
 
       - if: steps.check.outputs.js_files_added
         name: Add Comment to PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
       - name: Cache npm
         uses: actions/cache@v1
         id: npm-cache # use this to check for `cache-hit` (`steps.npm-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/superset-helm-lint.yml
+++ b/.github/workflows/superset-helm-lint.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           changed=$(ct list-changed  --print-config)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
         env:
           CT_CHART_DIRS: helm

--- a/scripts/tag_latest_release.sh
+++ b/scripts/tag_latest_release.sh
@@ -25,7 +25,7 @@ run_git_tag () {
   exit 0
 }
 
-echo "::set-output name=SKIP_TAG::false"
+echo "SKIP_TAG=false" >> "GITHUB_OUTPUT"
 DRY_RUN=false
 
 # get params passed in with script when it was run
@@ -62,7 +62,7 @@ fi
 if ! [[ ${GITHUB_TAG_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 then
   echo "This tag ${GITHUB_TAG_NAME} is not a valid release version. Not tagging."
-  echo "::set-output name=SKIP_TAG::true"
+  echo "SKIP_TAG=true" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
@@ -125,4 +125,4 @@ done
 
 echo "This release tag ${GITHUB_TAG_NAME} is not the latest. Not tagging."
 # if you've gotten this far, then we don't want to run any tags in the next step
-echo "::set-output name=SKIP_TAG::true"
+echo "SKIP_TAG=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### SUMMARY
Replacing deprecated "::set-output" with new "$GITHUB_OUTPUT"

See:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Issue:
https://github.com/datavisyn/github-maintenance/issues/18


